### PR TITLE
Add docs site

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,62 @@
+# API Reference
+
+!!! note
+    Unless specified otherwise, components documented here can be imported from `tartiflette_asgi` directly, e.g. `from tartiflette_asgi import TartifletteApp`.
+
+## `TartifletteApp`
+
+### Parameters
+
+**Note**: all parameters are keyword-only.
+
+- `engine` (`Engine`): a Tartiflette [engine](https://tartiflette.io/docs/api/engine). Required if `sdl` is not given.
+- `sdl` (`str`): a GraphQL schema defined using the [GraphQL Schema Definition Language](https://graphql.org/learn/schema/). Required if `engine` is not given.
+- `path` (`str`, optional): the path which clients should make GraphQL queries to. Defaults to `"/"`.
+- `graphiql` (`GraphiQL` or `bool`, optional): configuration for the GraphiQL client. Defaults to `True`, which is equivalent to `GraphiQL()`. Use `False` to not register the GraphiQL client.
+- `subscriptions` (`Subscriptions` or `bool`, optional): subscriptions configuration. Defaults to `True`, which is equivalent to `Subscriptions(path="/subscriptions")`. Leave empty or pass `None` to not register the subscription WebSocket endpoint.
+- `context` (`dict`, optional): a copy of this dictionary is passed to resolvers when executing a query. Defaults to `{}`. Note: the Starlette `Request` object is always present as `req`.
+- `schema_name` (`str`, optional): name of the GraphQL schema from the [Schema Registry](https://tartiflette.io/docs/api/schema-registry/) which should be used — mostly for advanced usage. Defaults to `"default"`.
+
+### Methods
+
+- `__call__(scope, receive, send)`: ASGI3 implementation.
+
+### Error responses
+
+| Status code                | Description                                                                                                                      |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| 400 Bad Request            | The GraphQL query could not be found in the request data.                                                                        |
+| 404 Not Found              | The request does not match the GraphQL or GraphiQL endpoint paths.                                                               |
+| 405 Method Not Allowed     | The HTTP method is not one of `GET`, `HEAD` or `POST`.                                                                           |
+| 415 Unsupported Media Type | The POST request made to the GraphQL endpoint uses a `Content-Type` different from `application/json` and `application/graphql`. |
+
+## `GraphiQL`
+
+Configuration helper for the GraphiQL client.
+
+### Parameters
+
+**Note**: all parameters are keyword-only.
+
+- `path` (`str`, optional): the path of the GraphiQL endpoint, **relative to the root path which `TartifletteApp` is served at**. If not given, defaults to the `path` given to `TartifletteApp`.
+- `default_headers` (`dict`, optional): extra HTTP headers to send when calling the GraphQL endpoint.
+- `default_query` (`str`, optional): the default query to display when accessing the GraphiQL interface.
+- `default_variables` (`dict`, optional): default [variables][graphql-variables] to display when accessing the GraphiQL interface.
+- `template` (`str`, optional): an HTML template to use instead of the default one. In the template, `default_headers`, `default_query` and `default_variables`, as well as the GraphQL `endpoint`, are available as strings (JSON-encoded if needed) using template string substitutions, e.g.:
+
+```js
+const endpoint = `${endpoint}`; // This is where the API call should be made.
+const defaultHeaders = JSON.parse(`${default_headers}`);
+```
+
+[graphql-variables]: https://graphql.org/learn/queries/#variables
+
+## `Subscriptions`
+
+Configuration helper for WebSocket subscriptions.
+
+### Parameters
+
+**Note**: all parameters are keyword-only.
+
+- `path` (`str`): the path of the subscriptions WebSocket endpoint, **relative to the root path which `TartifletteApp` is served at**. If not given, defaults to `/subscriptions`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,34 @@
+# FAQ
+
+## What is ASGI?
+
+ASGI provides a standard interface between async-capable Python web servers, frameworks, and applications. An ASGI application is a callable with the following signature:
+
+```python
+async def app(scope, receive, send) -> None:
+    ...
+```
+
+For more information, see the [ASGI documentation](https://asgi.readthedocs.io/en/latest/) and this list of [publications about ASGI](https://github.com/florimondmanca/awesome-asgi#publications).
+
+## Do I need to learn GraphQL/Tartiflette to use this package?
+
+**Yes**: once you've got the `TartifletteApp` ASGI app up and running, you're in Tartiflette territory.
+
+Here are some resources to get you started:
+
+- [Tartiflette tutorial](https://tartiflette.io/docs/tutorial/getting-started)
+- [Introduction to GraphQL](https://graphql.org/learn/)
+- [Tartiflette API reference](https://tartiflette.io/docs/api/engine)
+
+## Does this package ship with Tartiflette?
+
+**Yes**. Everything is included, which allows you to start building your GraphQL API right away. See also [Installation](#installation).
+
+## What is the role of Starlette?
+
+`tartiflette-asgi` uses Starlette as a lightweight ASGI toolkit: internally, it uses Starlette's request and response classes, and some other components.
+
+Luckily, this does not require your applications to use Starlette at all.
+
+For example, if you are [submounting your GraphQL app](#submounting-on-another-asgi-app) on an app built with an async web framework, this framework does not need to use Starlette — it just needs to speak ASGI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://mkdocs.org).
+
+## Commands
+
+- `mkdocs new [dir-name]` - Create a new project.
+- `mkdocs serve` - Start the live-reloading docs server.
+- `mkdocs build` - Build the documentation site.
+- `mkdocs help` - Print this help message.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,76 @@
-# Welcome to MkDocs
+<div align="center">
+  <img src="https://raw.githubusercontent.com/tartiflette/tartiflette-asgi/master/img/tartiflette-asgi.png" alt="tartiflette-asgi logo"/>
+</div>
 
-For full documentation visit [mkdocs.org](https://mkdocs.org).
+# Introduction
 
-## Commands
+`tartiflette-asgi` (previously `tartiflette-starlette`) is a wrapper that provides ASGI support for the [Tartiflette] Python GraphQL engine.
 
-- `mkdocs new [dir-name]` - Create a new project.
-- `mkdocs serve` - Start the live-reloading docs server.
-- `mkdocs build` - Build the documentation site.
-- `mkdocs help` - Print this help message.
+It is ideal for serving a GraphQL API over HTTP, or adding a GraphQL API endpoint to an existing ASGI application.
 
-## Project layout
+[tartiflette]: https://tartiflette.io
 
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+Build a GraphQL API using Tartiflette, then use `tartiflette-asgi` to achieve the following:
+
+- Serve your GraphQL API as a standalone ASGI application using an ASGI server (e.g. Uvicorn, Daphne or Hypercorn).
+- Mount your GraphQL API endpoint onto an existing ASGI application (built using e.g. Starlette, FastAPI, Responder, Quart or Sanic).
+- Make interactive queries using the built-in GraphiQL client.
+- Implement real-time querying thanks to GraphQL subscriptions over WebSocket.
+
+## Requirements
+
+`tartiflette-asgi` is compatible with:
+
+- Python 3.6, 3.7 or 3.8.
+- Tartiflette 1.x.
+
+## Installation
+
+First, install Tartiflette's external dependencies, as explained in the [Tartiflette tutorial](https://tartiflette.io/docs/tutorial/install-tartiflette).
+
+Then, you can install Tartiflette and `tartiflette-asgi` using `pip`:
+
+```bash
+pip install tartiflette "tartiflette-asgi==0.*"
+```
+
+You'll also need an [ASGI web server](https://github.com/florimondmanca/awesome-asgi#servers). We'll use [Uvicorn](http://www.uvicorn.org/) throughout this documentation:
+
+```bash
+pip install uvicorn
+```
+
+## Quickstart
+
+Create an application that exposes a `TartifletteApp` instance:
+
+```python
+from tartiflette import Resolver
+from tartiflette_asgi import TartifletteApp
+
+@Resolver("Query.hello")
+async def hello(parent, args, context, info):
+    name = args["name"]
+    return f"Hello, {name}!"
+
+sdl = "type Query { hello(name: String): String }"
+app = TartifletteApp(sdl=sdl, path="/graphql")
+```
+
+Save this file as `graphql.py`, then start the server:
+
+```bash
+uvicorn graphql:app
+```
+
+Make an HTTP request containing a GraphQL query:
+
+```bash
+curl http://localhost:8000/graphql -d '{ hello(name: "Chuck") }' -H "Content-Type: application/graphql"
+```
+
+You should get the following JSON response:
+
+```json
+{"data": {"hello": "Hello, Chuck!"}}
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,301 @@
+# User Guide
+
+## Creating an application
+
+The main piece of API that `tartiflette-asgi` brings is `TartifletteApp`, an ASGI3-compliant ASGI application.
+
+You can build it from either:
+
+- The Schema Definition Language (SDL):
+
+```python
+# This is an SDL string, but Tartiflette supports
+# other formats, e.g. paths to schema files or directories.
+sdl = "type Query { hello: String }"
+
+app = TartifletteApp(sdl=sdl)
+```
+
+- A Tartiflette `Engine` instance:
+
+```python
+from tartiflette import Engine
+
+engine = Engine(sdl=..., modules=[...])
+app = TartifletteApp(engine=engine)
+```
+
+For more information on what values `sdl` and `engine` can accept, see the [Engine API reference](https://tartiflette.io/docs/api/engine).
+
+## Routing
+
+You can define which URL path the `TartifletteApp` should be accessible at using the `path` parameter.
+
+It is served at `/` by default, but a popular choice is to serve it at `/graphql`:
+
+```python
+app = TartifletteApp(..., path="/graphql")
+```
+
+## Making requests
+
+`tartiflette-asgi` allows you to pass the query in several ways:
+
+- URL query string (methods: `GET`, `POST`):
+
+```bash
+curl 'http://localhost:8000/graphql?query=\{hello(name:"Chuck")\}'
+```
+
+- JSON-encoded body (methods: `POST`):
+
+```bash
+curl http://localhost:8000/graphql \
+  -d '{"query": "{ hello(name: \"Chuck\") }"}' \
+  -H "Content-Type: application/json"
+```
+
+- Raw body with the `application/graphql` content type (methods: `POST`):
+
+```bash
+curl http://localhost:8000/graphql \
+  -d '{ hello(name: "Chuck") }' \
+  -H "Content-Type: application/graphql"
+```
+
+## GraphiQL client
+
+### Default behavior
+
+When you access the GraphQL endpoint in a web browser, `TartifletteApp` serves a [GraphiQL](https://github.com/graphql/graphiql) client, which allows you to make interactive GraphQL queries in the browser.
+
+![](https://github.com/tartiflette/tartiflette-asgi/raw/master/img/graphiql.png)
+
+### Customization
+
+You can customize the GraphiQL interface using `TartifletteApp(graphiql=GraphiQL(...))`.
+
+For example, this snippet will:
+
+- Serve the GraphiQL web interface at `/graphiql`.
+- Send an `Authorization` header when making requests to the API endpoint.
+- Setup the default variables and query to show when accessing the web interface for the first time.
+
+```python
+from tartiflette_asgi import TartifletteApp, GraphiQL
+
+sdl = "type Query { hello(name: String): String }"
+
+graphiql = GraphiQL(
+    path="/graphiql",
+    default_headers={"Authorization": "Bearer 123"},
+    default_variables={"name": "world"},
+    default_query="""
+    query Hello($name: String) {
+        hello(name: $name)
+    }
+    """,
+)
+
+app = TartifletteApp(sdl=sdl, graphiql=graphiql)
+```
+
+If you run this application, you should see the customized GraphiQL client when accessing [http://localhost:8000/graphiql](http://localhost:8000/graphiql):
+
+![](https://raw.githubusercontent.com/tartiflette/tartiflette-asgi/master/img/graphiql-custom.png)
+
+For the full list of options, see [`GraphiQL`](/api/#graphiql).
+
+### Disabling the GraphiQL client
+
+To disable the GraphiQL client altogether, use `TartifletteApp(graphiql=False)`.
+
+## ASGI sub-mounting
+
+You can mount a `TartifletteApp` instance as a sub-route of another ASGI application.
+
+This is useful to have a GraphQL endpoint _and_ other (non-GraphQL) endpoints within a single application. For example, you may wnat to have a REST endpoint at `/api/users`, or serve an HTML page at `/index.html`, as well as expose a GraphQL endpoint at `/graphql`.
+
+How to achieve this depends on the specific ASGI web framework you are using, so this section documents how to achieve it in various situations.
+
+### General approach
+
+In general, you'll need to do the following:
+
+1. Create a `TartifletteApp` application instance.
+1. Mount it under the main ASGI application's router. (Most ASGI frameworks expose a method such as `.mount()` for this purpose.)
+1. Register the startup lifespan event handler on the main ASGI application. (Frameworks typically expose a method such as `.add_event_handler()` for this purpose.)
+
+!!! important
+    The startup event handler is responsible for preparing the GraphQL engine (a.k.a. [cooking the engine](https://tartiflette.io/docs/api/engine#cook-your-tartiflette)), e.g. loading modules, SDL files, etc.
+
+    If your ASGI framework does not implement the lifespan protocol and/or does not allow to register custom lifespan event handlers, or if you're working at the raw ASGI level, you can still use `tartiflette-asgi` but you'll need to add lifespan support yourself, e.g. using [asgi-lifespan](https://github.com/florimondmanca/asgi-lifespan).
+
+### Routing
+
+Although `TartifletteApp` has minimal support for [routing](#routing), when using ASGI sub-mounting you'll probably want to leave the `path` parameter on `TartifletteApp` empty, e.g. use:
+
+```python
+graphql = TartifletteApp(sdl=...)
+app.mount("/graphql", app=graphql)
+```
+
+This is because `path` is relative to the mount path on the host ASGI application. As a result, mounting at `/graphql` while setting `path="/graphql"` would make the GraphQL API accessible at `/graphql/graphql`, which is typically not what you want.
+
+If you want to have your GraphQL API accessible at `/graphql`, you should do as above, i.e.:
+
+- Leave `path` empty on `TartifletteApp`.
+- Mount it at `/graphql` on the host ASGI app.
+
+(Mounting at `/` and setting `path="/graphql"` typically won't have the behavior you'd expect. For example, Starlette would send all requests to your GraphQL endpoint, regardless of whether the requested URL path.)
+
+### Examples
+
+This section documents how to mount a `TartifletteApp` instance under an ASGI application for various ASGI web frameworks.
+
+To run an example:
+
+- Save the application script as `graphql.py`.
+- Run the server using `$ uvicorn graphql:app`.
+- Make a request using:
+
+```bash
+curl http://localhost:8000/graphql -d '{ hello(name: "Chuck") }' -H "Content-Type: application/graphql"
+```
+
+#### Starlette
+
+```python
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from tartiflette import Resolver
+from tartiflette_asgi import TartifletteApp
+
+# Create a Starlette application.
+
+app = Starlette()
+
+# Maybe add some non-GraphQL routes...
+
+@app.route("/")
+async def home(request):
+  return PlainTextResponse("Hello, world!")
+
+# Create a 'TartifletteApp' instance.
+
+@Resolver("Query.hello")
+async def hello(parent, args, context, info):
+    name = args["name"]
+    return f"Hello, {name}!"
+
+sdl = "type Query { hello(name: String): String }"
+graphql = TartifletteApp(sdl=sdl)
+
+# Mount it under the Starlette application.
+
+app.mount("/graphql", graphql)
+app.add_event_handler("startup", graphql.startup)
+```
+
+## Advanced usage
+
+### Accessing request information
+
+All the information about the current HTTP request (URL, headers, query parameters, etc) is available on `context["req"]`, which returns a Starlette `Request` object representing the current HTTP request.
+
+```python
+@Resolver("Query.whoami")
+async def resolve_whoami(parent, args, context, info):
+    request = context["req"]
+    who = request.query_params.get("username", "unknown")
+    return who
+```
+
+For detailed usage notes about the `Request` object, see [Requests](https://www.starlette.io/requests/) in the Starlette documentation.
+
+### Shared GraphQL context
+
+If you need to make services, functions or data available to GraphQL resolvers, you can use `TartifletteApp(context=...)`. Contents of the `context` argument will be merged into the GraphQL `context` passed to resolvers.
+
+For example:
+
+```python
+import os
+from tartiflette import Resolver
+from tartiflette_asgi import TartifletteApp
+
+@Resolver("Query.human")
+async def resolve_human(parent, args, context, info):
+    planet = context["planet"]
+    return f"Human living on {planet}"
+
+app = TartifletteApp(
+  sdl="type Query { human(): String }",
+  context={"planet": os.getenv("PLANET", "Earth")},
+)
+```
+
+### WebSocket subscriptions
+
+This package provides support for [GraphQL subscriptions](https://graphql.org/blog/subscriptions-in-graphql-and-relay/) over WebSocket. Subscription queries can be issued via the built-in GraphiQL client, as well as [Apollo GraphQL](https://www.apollographql.com/docs/react/advanced/subscriptions/) and any other client that uses the [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md) protocol.
+
+Example:
+
+```python
+import asyncio
+from tartiflette import Subscription
+from tartiflette_asgi import TartifletteApp, GraphiQL
+
+sdl = """
+type Query {
+  _: Boolean
+}
+
+type Subscription {
+  timer(seconds: Int!): Timer
+}
+
+enum Status {
+  RUNNING
+  DONE
+}
+
+type Timer {
+  remainingTime: Int!
+  status: Status!
+}
+"""
+
+@Subscription("Subscription.timer")
+async def on_timer(parent, args, context, info):
+    seconds = args["seconds"]
+    for i in range(seconds):
+        yield {"timer": {"remainingTime": seconds - i, "status": "RUNNING"}}
+        await asyncio.sleep(1)
+    yield {"timer": {"remainingTime": 0, "status": "DONE"}}
+
+app = TartifletteApp(
+    sdl=sdl,
+    subscriptions=True,
+    graphiql=GraphiQL(
+        default_query="""
+        subscription {
+          timer(seconds: 5) {
+            remainingTime
+            status
+          }
+        }
+        """
+    ),
+)
+```
+
+> **Note**: the subscriptions endpoint is exposed on `/subscriptions` by default.
+
+Save this file as `graphql.py`, then run `$ uvicorn graphql:app`. Open the GraphiQL client at http://localhost:8000, and hit "Play"! The timer should update on real-time.
+
+![](https://github.com/tartiflette/tartiflette-asgi/raw/master/img/graphiql-subscriptions.png)
+
+See [`Subscriptions`](/api/#subscriptions) in the API reference for a complete description of the available options.
+
+For more information on using subscriptions in Tartiflette, see the [Tartiflette documentation](https://tartiflette.io/docs/api/subscription).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,9 @@ site_description: ASGI support for the Tartiflette Python GraphQL engine
 
 theme:
   name: material
+  palette:
+    primary: "black"
+    accent: "orange"
 
 repo_name: tartiflette/tartiflette-asgi
 repo_url: https://github.com/tartiflette/tartiflette-asgi
@@ -10,7 +13,14 @@ edit_uri: ""
 
 nav:
   - Introduction: "index.md"
+  - User Guide: "usage.md"
+  - API Reference: "api.md"
+  - FAQ: "faq.md"
+  - Contributing: "https://github.com/tartiflette/tartiflette-asgi/tree/master/CONTRIBUTING.md"
+  - Changelog: "https://github.com/tartiflette/tartiflette-asgi/tree/master/CHANGELOG.md"
 
 markdown_extensions:
+  - admonition
   - codehilite:
       guess_lang: false
+  - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,16 @@
+site_name: tartiflette-asgi
+site_description: ASGI support for the Tartiflette Python GraphQL engine
+
+theme:
+  name: material
+
+repo_name: tartiflette/tartiflette-asgi
+repo_url: https://github.com/tartiflette/tartiflette-asgi
+edit_uri: ""
+
+nav:
+  - Introduction: "index.md"
+
+markdown_extensions:
+  - codehilite:
+      guess_lang: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ flake8-bugbear
 flake8-comprehensions
 flake8-pie
 isort
+mkdocs
+mkdocs-material
 mypy
 pyee>=6,<7
 pytest


### PR DESCRIPTION
Fixes #86 

![Screenshot 2019-10-31 at 12 39 42](https://user-images.githubusercontent.com/15911462/67943971-9ce25900-fbdb-11e9-955d-f044044edbe7.png)

Follow-up steps:

- Update the `publish` script with `mkdocs gh-deploy`, and add a `Docs` job to Travis CI to test that documentation builds correctly.
- Deploy!
- If all looks well, slim the README down to only contain the quickstart guide, then point to the docs site.
- Move API reference to docstrings and generate it with [mkautodoc](https://github.com/tomchristie/mkautodoc).