### PR TITLE
Adapt Starlette doc usage according starlette v13

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -168,16 +168,12 @@ curl http://localhost:8000/graphql -d '{ hello(name: "Chuck") }' -H "Content-Typ
 ```python
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
+from starlette.routing import Route
 from tartiflette import Resolver
 from tartiflette_asgi import TartifletteApp
 
-# Create a Starlette application.
-
-app = Starlette()
-
 # Maybe add some non-GraphQL routes...
 
-@app.route("/")
 async def home(request):
   return PlainTextResponse("Hello, world!")
 
@@ -190,6 +186,13 @@ async def hello(parent, args, context, info):
 
 sdl = "type Query { hello(name: String): String }"
 graphql = TartifletteApp(sdl=sdl)
+
+# Create a Starlette application.
+
+routes = [
+    Route("/", endpoint=home)
+]
+app = Starlette(routes=routes)
 
 # Mount it under the Starlette application.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -194,8 +194,7 @@ routes = [
     Route("/", endpoint=home),
     Mount("/graphql", graphql),
 ]
-app = Starlette(routes=routes)
-app.add_event_handler("startup", graphql.startup)
+app = Starlette(routes=routes, on_startup=graphql.startup)
 ```
 
 ## Advanced usage

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -194,7 +194,7 @@ routes = [
     Route("/", endpoint=home),
     Mount("/graphql", graphql),
 ]
-app = Starlette(routes=routes, on_startup=graphql.startup)
+app = Starlette(routes=routes, on_startup=[graphql.startup])
 ```
 
 ## Advanced usage

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,7 +127,7 @@ In general, you'll need to do the following:
 1. Register the startup lifespan event handler on the main ASGI application. (Frameworks typically expose a method such as `.add_event_handler()` for this purpose.)
 
 !!! important
-The startup event handler is responsible for preparing the GraphQL engine (a.k.a. [cooking the engine](https://tartiflette.io/docs/api/engine#cook-your-tartiflette)), e.g. loading modules, SDL files, etc.
+    The startup event handler is responsible for preparing the GraphQL engine (a.k.a. [cooking the engine](https://tartiflette.io/docs/api/engine#cook-your-tartiflette)), e.g. loading modules, SDL files, etc.
 
     If your ASGI framework does not implement the lifespan protocol and/or does not allow to register custom lifespan event handlers, or if you're working at the raw ASGI level, you can still use `tartiflette-asgi` but you'll need to add lifespan support yourself, e.g. using [asgi-lifespan](https://github.com/florimondmanca/asgi-lifespan).
 


### PR DESCRIPTION
As far I understand, [route decorator is on the way to be deprecated](https://github.com/encode/starlette/pull/704).

I have seen that starlette is freezed at ``starlette>=0.12,<0.13`` hope this helps on the way to move ahead !