### PR TITLE
Move CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: scripts/install
+      - name: Run checks
+        run: scripts/check
+      - name: Build docs
+        run: scripts/docs
+
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: scripts/install
+      - name: Run tests
+        run: scripts/test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Checks
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +24,7 @@ jobs:
         run: scripts/docs
 
   test:
-    name: Python ${{ matrix.python-version }}
+    name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,13 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: scripts/install
       - name: Run checks
@@ -36,6 +43,13 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: scripts/install
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 </div>
 
 <p align="center">
-  <a href="https://travis-ci.org/tartiflette/tartiflette-asgi">
-    <img src="https://travis-ci.org/tartiflette/tartiflette-asgi.svg?branch=master" alt="Build status">
+  <a href="https://github.com/tartiflette/tartiflette-asgi/actions">
+    <img src="https://github.com/tartiflette/tartiflette-asgi/workflows/Build/badge.svg?branch=master" alt="Build status">
   </a>
   <a href="https://pypi.org/project/tartiflette-asgi">
     <img src="https://badge.fury.io/py/tartiflette-asgi.svg" alt="Package version">

--- a/scripts/docs
+++ b/scripts/docs
@@ -5,12 +5,6 @@ if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
 
-if ! command -v "${PREFIX}mkdocs" &>/dev/null ; then
-    echo "Unable to find the 'mkdocs' command."
-    echo "Install from PyPI, using '${PREFIX}pip install mkdocs'."
-    exit 1
-fi
-
 set -x
 
 ${PREFIX}mkdocs build

--- a/scripts/install
+++ b/scripts/install
@@ -1,13 +1,14 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 
-if [ -z $CI ]; then
+if [ -z $GITHUB_ACTIONS ]; then
   python -m venv venv
   export PREFIX="venv/bin/"
 else
   export PREFIX=""
+  # Tartiflette requires these binaries to be installed, but
+  # they don't come installed on Actions' Ubuntu.
+  sudo apt-get install cmake flex bison
 fi
-
-set -x
 
 ${PREFIX}pip install -U pip
 ${PREFIX}pip install -r requirements.txt

--- a/scripts/test
+++ b/scripts/test
@@ -7,7 +7,7 @@ fi
 
 set -x
 
-if [[ -z $CI ]]; then
+if [[ -z $GITHUB_ACTIONS ]]; then
     scripts/check
 fi
 


### PR DESCRIPTION
**Motivation**
- Travis/GitHub integration seems broken, so we're not getting status reported back for whatever reason.
- The Tartiflette org is using GitHub Actions generally, so it's a good alternative.