### PR TITLE
[FIX] Use wss when the window.location.protocol is https

### DIFF
--- a/tartiflette_asgi/graphiql.html
+++ b/tartiflette_asgi/graphiql.html
@@ -142,7 +142,7 @@
         parameters.fetcher = graphQLFetcher;
       } else {
         var subscriptionsURL = [
-          "ws://",
+          window.location.protocol === "https:" ? "wss://" : "ws://",
           window.location.hostname,
           window.location.port ? ":" + window.location.port : "",
           subscriptionsEndpoint


### PR DESCRIPTION
When you run GraphiQL using https and you use subscriptions you get an error because by default it connects to `ws` instead of `wss`.

This PR use `ws` or `wss` depending on `window.location.protocol` value.