### PR TITLE
Use HTTPX as the HTTP test client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,21 @@
 -e .
 
+asgi-lifespan
+async-generator; python_version<'3.7'
 autoflake
 black
 flake8
 flake8-bugbear
 flake8-comprehensions
 flake8-pie
+httpx==0.13.*
 isort
 mkdocs
 mkdocs-material
 mypy
 pyee>=6,<8
 pytest
+pytest-asyncio
 requests  # Required by the Starlette test client.
 seed-isort-config
 twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,6 @@ combine_as_imports = True
 force_grid_wrap = 0
 include_trailing_comma = True
 known_first_party = tartiflette_asgi,tests
-known_third_party = pyee,pytest,setuptools,starlette,tartiflette
+known_third_party = asgi_lifespan,httpx,pyee,pytest,setuptools,starlette,tartiflette
 line_length = 88
 multi_line_output = 3

--- a/tests/_compat.py
+++ b/tests/_compat.py
@@ -1,0 +1,5 @@
+try:
+    from contextlib import asynccontextmanager
+except ImportError:  # pragma: no cover
+    # Python 3.6
+    from async_generator import asynccontextmanager  # type: ignore  # noqa: F401

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,6 +1,17 @@
 import typing
 
+import httpx
+from asgi_lifespan import LifespanManager
 from pyee import AsyncIOEventEmitter
+
+from ._compat import asynccontextmanager
+
+
+@asynccontextmanager
+async def get_client(app: typing.Callable) -> typing.AsyncIterator:
+    async with LifespanManager(app):
+        async with httpx.AsyncClient(app=app, base_url="http://testserver/") as client:
+            yield client
 
 
 def omit_none(dct: dict) -> dict:

--- a/tests/test_graphql_api.py
+++ b/tests/test_graphql_api.py
@@ -1,83 +1,95 @@
 import pytest
-from starlette.testclient import TestClient
 from tartiflette import Engine
 
 from tartiflette_asgi import TartifletteApp
 
+from ._utils import get_client
 
-def test_get_querystring(engine: Engine) -> None:
+
+@pytest.mark.asyncio
+async def test_get_querystring(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
-    with TestClient(app) as client:
-        response = client.get("/?query={ hello }")
+    async with get_client(app) as client:
+        response = await client.get("/?query={ hello }")
     assert response.status_code == 200
     assert response.json() == {"data": {"hello": "Hello stranger"}}
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("path", ("/", "/?foo=bar", "/?q={ hello }"))
-def test_get_no_query(engine: Engine, path: str) -> None:
+async def test_get_no_query(engine: Engine, path: str) -> None:
     app = TartifletteApp(engine=engine)
-    with TestClient(app) as client:
-        response = client.get(path)
+    async with get_client(app) as client:
+        response = await client.get(path)
     assert response.status_code == 400
     assert response.text == "No GraphQL query found in the request"
 
 
-def test_post_querystring(engine: Engine) -> None:
+@pytest.mark.asyncio
+async def test_post_querystring(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
-    with TestClient(app) as client:
-        response = client.post("/?query={ hello }")
+    async with get_client(app) as client:
+        response = await client.post("/?query={ hello }")
     assert response.status_code == 200
     assert response.json() == {"data": {"hello": "Hello stranger"}}
 
 
-def test_post_json(engine: Engine) -> None:
+@pytest.mark.asyncio
+async def test_post_json(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
-    with TestClient(app) as client:
-        response = client.post("/", json={"query": "{ hello }"})
+    async with get_client(app) as client:
+        response = await client.post("/", json={"query": "{ hello }"})
     assert response.status_code == 200
     assert response.json() == {"data": {"hello": "Hello stranger"}}
 
 
-def test_post_invalid_json(engine: Engine) -> None:
+@pytest.mark.asyncio
+async def test_post_invalid_json(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
-    with TestClient(app) as client:
-        response = client.post(
+    async with get_client(app) as client:
+        response = await client.post(
             "/", data="{test", headers={"content-type": "application/json"}
         )
     assert response.status_code == 400
     assert response.json() == {"error": "Invalid JSON."}
 
 
-def test_post_graphql(engine: Engine) -> None:
+@pytest.mark.asyncio
+async def test_post_graphql(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
-    with TestClient(app) as client:
-        response = client.post(
+    async with get_client(app) as client:
+        response = await client.post(
             "/", data="{ hello }", headers={"content-type": "application/graphql"}
         )
     assert response.status_code == 200
     assert response.json() == {"data": {"hello": "Hello stranger"}}
 
 
-def test_post_invalid_media_type(engine: Engine) -> None:
+@pytest.mark.asyncio
+async def test_post_invalid_media_type(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
-    with TestClient(app) as client:
-        response = client.post("/", data="{ hello }", headers={"content-type": "dummy"})
+    async with get_client(app) as client:
+        response = await client.post(
+            "/", data="{ hello }", headers={"content-type": "dummy"}
+        )
     assert response.status_code == 415
     assert response.text == "Unsupported Media Type"
 
 
-def test_put(engine: Engine) -> None:
+@pytest.mark.asyncio
+async def test_put(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
-    with TestClient(app) as client:
-        response = client.put("/", json={"query": "{ hello }"})
+    async with get_client(app) as client:
+        response = await client.put("/", json={"query": "{ hello }"})
     assert response.status_code == 405
     assert response.text == "Method Not Allowed"
 
 
-def test_error_handling(engine: Engine) -> None:
+@pytest.mark.asyncio
+async def test_error_handling(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
-    with TestClient(app) as client:
-        response = client.post("/", json={"query": "{ dummy }"})
+    async with get_client(app) as client:
+        response = await client.post("/", json={"query": "{ dummy }"})
     assert response.status_code == 400
     json = response.json()
     assert json["data"] is None

--- a/tests/test_tartiflette_app.py
+++ b/tests/test_tartiflette_app.py
@@ -1,15 +1,18 @@
-from starlette.testclient import TestClient
+import pytest
 from tartiflette import Engine
 
 from tartiflette_asgi import TartifletteApp
 
+from ._utils import get_client
 
-def test_path(engine: Engine) -> None:
+
+@pytest.mark.asyncio
+async def test_path(engine: Engine) -> None:
     app = TartifletteApp(engine=engine, path="/graphql")
 
-    with TestClient(app) as client:
-        assert client.get("/").status_code == 404
-        response = client.get("/graphql?query={ hello }")
-
-    assert response.status_code == 200
-    assert response.json() == {"data": {"hello": "Hello stranger"}}
+    async with get_client(app) as client:
+        response = await client.get("/")
+        assert response.status_code == 404
+        response = await client.get("/graphql?query={ hello }")
+        assert response.status_code == 200
+        assert response.json() == {"data": {"hello": "Hello stranger"}}


### PR DESCRIPTION
Fixes #108 

Motivation: run tests in a "pure" async environment.

**Note**: subscription tests still use the Starlette `TestClient`, since HTTPX doesn't have WebSocket support.