### PR TITLE
Alter endpoint context behavior.

### DIFF
--- a/src/tartiflette_asgi/_endpoints.py
+++ b/src/tartiflette_asgi/_endpoints.py
@@ -61,12 +61,13 @@ class GraphQLEndpoint(HTTPEndpoint):
 
         config = get_graphql_config(request)
         background = BackgroundTasks()
-        context = {"req": request, "background": background, **config.context}
+        context_additions = {"req": request, "background": background}
+        config.context.update(context_additions)
 
         engine: Engine = config.engine
         result: dict = await engine.execute(
             query,
-            context=context,
+            context=config.context,
             variables=data.get("variables"),
             operation_name=data.get("operationName"),
         )


### PR DESCRIPTION
Currently, in GraphQLEndpoint._get_response(), it makes a new dictionary and adds data from the provided context dictionary to it. This can be an issue if a custom dictionary class is provided as the context.
In my opinion as well it makes more sense to add to the provided dict instead of replacing it.
As far as I can tell I don't see any breaking issues with this change.