### PR TITLE
Follow common practices for return statuses

### DIFF
--- a/src/tartiflette_asgi/_endpoints.py
+++ b/src/tartiflette_asgi/_endpoints.py
@@ -71,13 +71,22 @@ class GraphQLEndpoint(HTTPEndpoint):
             operation_name=data.get("operationName"),
         )
 
-        content = {"data": result["data"]}
-        has_errors = "errors" in result
-        if has_errors:
-            content["errors"] = format_errors(result["errors"])
-        status = 400 if has_errors else 200
+        status_code = 200
+        content = {}
 
-        return JSONResponse(content=content, status_code=status, background=background)
+        if result.get("data"):
+            content["data"] = result["data"]
+
+        result_errors = result.get("errors")
+
+        if result_errors:
+            content["errors"] = []
+            for e in result_errors:
+                content["errors"].append(_format_error(e))
+                if e.get("extensions", {}).get("rule"):
+                    status_code = 400
+
+        return JSONResponse(content=content, status_code=status_code, background=background)
 
     async def dispatch(self) -> None:
         request = Request(self.scope, self.receive)


### PR DESCRIPTION
According to the spec, data should only be populated if there's any valid result. Regarding the errors, there's no definition in the spec about rest status codes but the common practice is to always return 200 unless there were graphql parsing/syntax/schema related errors, in which case 400 is returned.

The way to determine if it was a parsing/syntax/schema error is to check if the rule or spec is specified in the error (to distinguish from user generated errors)