### PR TITLE
Drop flake8-pie

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ black==20.8b1
 flake8
 flake8-bugbear
 flake8-comprehensions
-flake8-pie
 httpx==0.14.*
 isort==5.*
 mkdocs

--- a/src/tartiflette_asgi/_subscriptions/protocol.py
+++ b/src/tartiflette_asgi/_subscriptions/protocol.py
@@ -59,7 +59,7 @@ class GraphQLWSProtocol:
                 if opid not in self._operations:
                     break
                 await self._send_message(opid, optype="data", payload=item)
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             await self._send_error("Internal error", opid=opid)
             raise exc
 
@@ -77,7 +77,7 @@ class GraphQLWSProtocol:
     async def _on_connection_init(self, opid: str, payload: dict) -> None:
         try:
             await self._send_message(optype=GQL.CONNECTION_ACK)
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             await self._send_error(str(exc), opid=opid, error_type=GQL.CONNECTION_ERROR)
             await self.close(1011)
 

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -19,7 +19,7 @@ def omit_none(dct: dict) -> dict:
 
 
 PubSub = AsyncIOEventEmitter
-pubsub = PubSub()  # pylint: disable=invalid-name
+pubsub = PubSub()
 
 
 class Dog(typing.NamedTuple):


### PR DESCRIPTION
**Description**
* Drop `flake8-pie` plugin

**Motivation**
* `flake8-pie` only provides 4 lints that we don't really need in this repo: https://pypi.org/project/flake8-pie/
* A new naggy "don't use broad excepts" was introduced, which we don't really care about but it blocks PR builds (eg https://github.com/tartiflette/tartiflette-asgi/pull/132)