### PR TITLE
Add type hints to fix static checks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,11 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    install_requires=["starlette==0.13.*", "tartiflette>=1.0,<1.4"],
+    install_requires=[
+        "starlette==0.13.*",
+        "tartiflette>=1.0,<1.4",
+        "typing_extensions; python_version<'3.8'",
+    ],
     python_requires=">=3.6",
     # https://pypi.org/pypi?%3Aaction=list_classifiers
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         "starlette==0.13.*",
         "tartiflette>=1.0,<1.4",
-        "typing_extensions; python_version<'3.8'",
+        "typing-extensions; python_version<'3.8'",
     ],
     python_requires=">=3.6",
     # https://pypi.org/pypi?%3Aaction=list_classifiers

--- a/src/tartiflette_asgi/_subscriptions/impl.py
+++ b/src/tartiflette_asgi/_subscriptions/impl.py
@@ -36,11 +36,12 @@ class GraphQLWSProtocol(protocol.GraphQLWSProtocol):
 
     # GraphQL engine implementation.
 
-    def get_stream(self, opid: str, payload: dict) -> typing.AsyncGenerator:
+    def get_stream(self, opid: str, payload: protocol.Payload) -> protocol.Stream:
         context = {**payload.get("context", {}), **self.context}
-        return self.engine.subscribe(
-            query=payload.get("query"),
+        result = self.engine.subscribe(
+            query=payload["query"],
             variables=payload.get("variables"),
             operation_name=payload.get("operationName"),
             context=context,
         )
+        return typing.cast(protocol.Stream, result)

--- a/src/tartiflette_asgi/_subscriptions/protocol.py
+++ b/src/tartiflette_asgi/_subscriptions/protocol.py
@@ -8,11 +8,21 @@ import typing
 from .constants import GQL
 
 
+class Payload(typing.TypedDict):
+    context: dict
+    query: typing.Union[str, bytes]
+    variables: typing.Optional[typing.Dict[str, typing.Any]]
+    operationName: typing.Optional[str]
+
+
+Stream = typing.AsyncGenerator[typing.Dict[str, typing.Any], None]
+
+
 class GraphQLWSProtocol:
     name = "graphql-ws"
 
     def __init__(self) -> None:
-        self._operations: typing.Dict[str, typing.AsyncGenerator] = {}
+        self._operations: typing.Dict[str, Stream] = {}
 
     # Methods whose implementation is left to the implementer.
 
@@ -25,7 +35,7 @@ class GraphQLWSProtocol:
     async def close(self, close_code: int) -> None:
         raise NotImplementedError
 
-    def get_stream(self, opid: str, payload: dict) -> typing.AsyncGenerator:
+    def get_stream(self, opid: str, payload: Payload) -> Stream:
         raise NotImplementedError
 
     # Helpers.
@@ -50,7 +60,7 @@ class GraphQLWSProtocol:
             error_type = GQL.ERROR
         await self._send_message(opid, error_type, {"message": message})
 
-    async def _subscribe(self, opid: str, payload: dict) -> None:
+    async def _subscribe(self, opid: str, payload: Payload) -> None:
         stream = self.get_stream(opid, payload)
         self._operations[opid] = stream
 
@@ -74,22 +84,22 @@ class GraphQLWSProtocol:
 
     # Client message handlers.
 
-    async def _on_connection_init(self, opid: str, payload: dict) -> None:
+    async def _on_connection_init(self, opid: str, payload: Payload) -> None:
         try:
             await self._send_message(optype=GQL.CONNECTION_ACK)
         except Exception as exc:
             await self._send_error(str(exc), opid=opid, error_type=GQL.CONNECTION_ERROR)
             await self.close(1011)
 
-    async def _on_start(self, opid: str, payload: dict) -> None:
+    async def _on_start(self, opid: str, payload: Payload) -> None:
         if opid in self._operations:
             await self._unsubscribe(opid)
         await self._subscribe(opid, payload)
 
-    async def _on_stop(self, opid: str, payload: dict) -> None:
+    async def _on_stop(self, opid: str, payload: Payload) -> None:
         await self._unsubscribe(opid)
 
-    async def _on_connection_terminate(self, opid: str, payload: dict) -> None:
+    async def _on_connection_terminate(self, opid: str, payload: Payload) -> None:
         await self.close(1011)
 
     # Main task.
@@ -105,9 +115,9 @@ class GraphQLWSProtocol:
 
         optype: str = message.get("type")
         opid: str = message.get("id")
-        payload: dict = message.get("payload", {})
+        payload: Payload = message.get("payload", {})
 
-        handler: typing.Callable[[str, dict], typing.Awaitable[None]]
+        handler: typing.Callable[[str, Payload], typing.Awaitable[None]]
 
         if optype == "connection_init":
             handler = self._on_connection_init

--- a/src/tartiflette_asgi/_subscriptions/protocol.py
+++ b/src/tartiflette_asgi/_subscriptions/protocol.py
@@ -3,12 +3,18 @@
 See: https://github.com/apollographql/subscriptions-transport-ws
 """
 import json
+import sys
 import typing
 
 from .constants import GQL
 
+if sys.version_info >= (3, 8):  # pragma: no cover
+    from typing import TypedDict
+else:  # pragma: no cover
+    from typing_extensions import TypedDict
 
-class Payload(typing.TypedDict):
+
+class Payload(TypedDict):
     context: dict
     query: typing.Union[str, bytes]
     variables: typing.Optional[typing.Dict[str, typing.Any]]


### PR DESCRIPTION
The static checks were broken when `tartiflette 1.3.2` was released, which exposed their type hints to downstream packages.
This PR adds type hints to satisfy the static checks.