### PR TITLE
Add support for tartiflette 1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    install_requires=["starlette==0.13.*", "tartiflette>=1.0,<1.4"],
+    install_requires=["starlette==0.13.*", "tartiflette>=1.0,<1.5"],
     python_requires=">=3.6",
     # https://pypi.org/pypi?%3Aaction=list_classifiers
     license="MIT",


### PR DESCRIPTION
Update requirements to support tartiflette 1.4, which closes #152 . Type checks are failing, but are resolved in #150.