### PR TITLE
Add support for starlette 1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    install_requires=["starlette==0.13.*", "tartiflette>=1.0,<1.4"],
+    install_requires=["starlette==0.16.*", "tartiflette>=1.0,<1.4"],
     python_requires=">=3.6",
     # https://pypi.org/pypi?%3Aaction=list_classifiers
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "starlette==0.16.*",
+        "starlette>=0.13,<1.0",
         "tartiflette>=1.0,<1.5",
         "typing-extensions; python_version<'3.8'",
     ],

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -25,7 +25,8 @@ def test_if_subscriptions_disabled_then_cannot_connect(
 
     with TestClient(app) as client:  # type: TestClient  # type: ignore
         with pytest.raises(WebSocketDisconnect):
-            client.websocket_connect("/subscriptions")
+            with client.websocket_connect("/subscriptions"):
+                pass
 
 
 @pytest.fixture(name="pubsub", scope="session")


### PR DESCRIPTION
Closed #157

Update requirements to support starlette 1.6. Type checks are failing, but are resolved in #150.

Minor adjustment required for test, due to the starlette 1.5 release: https://github.com/encode/starlette/releases/tag/0.15.0
> TestClient.websocket_connect() now must be used as a context manager.

