### PR TITLE
Refactor internal subscription streams

### DIFF
--- a/src/tartiflette_asgi/_subscriptions/impl.py
+++ b/src/tartiflette_asgi/_subscriptions/impl.py
@@ -36,12 +36,22 @@ class GraphQLWSProtocol(protocol.GraphQLWSProtocol):
 
     # GraphQL engine implementation.
 
-    def get_stream(self, opid: str, payload: protocol.Payload) -> protocol.Stream:
+    def get_subscription(
+        self, opid: str, payload: protocol.Payload
+    ) -> protocol.Subscription:
         context = {**payload.get("context", {}), **self.context}
-        result = self.engine.subscribe(
+        aiterator = self.engine.subscribe(
             query=payload["query"],
             variables=payload.get("variables"),
             operation_name=payload.get("operationName"),
             context=context,
         )
-        return typing.cast(protocol.Stream, result)
+
+        # `tartiflette` type hints say it returns an `AsyncIterable` (doesn't
+        # include `aclose`), but it is actually a full-fledged `AsyncGenerator`
+        # which we want to be closing at some point.
+        agen = typing.cast(
+            typing.AsyncGenerator[typing.Dict[str, typing.Any], None], aiterator
+        )
+
+        return protocol.Subscription(agen)


### PR DESCRIPTION
Follow-up to #150 

From `tartiflette==1.3.2`, Tartiflette ships with type hints, and `engine.subscribe()` is marked as returning an `AsyncIterator`. This is not fully correct, as it _actually_ returns an async generator (a detail which we rely on to properly close it). But since we don't have our own "subscription stream" abstraction, this detail kind of bubbles up through. This PR adds a well-defined `Subscription` class (that just happens to be a perfect wrapper around an async generator).