### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update dependency on Starlette to `0.16.*`. (Pull #154)
-- Refactor internal subscription streams (Pull #156)
 - Update httpx requirement to `0.19.*` (Pull #159)
 
 ## 0.10.0 - 2021-01-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 - 2021-08-27
+
+### Added
+
+- Add official compatibility with Tartiflette 1.4.x. (Pull #153)
+
+### Changed
+
+- Update dependency on Starlette to `0.16.*`. (Pull #154)
+- Refactor internal subscription streams (Pull #156)
+- Update httpx requirement to `0.19.*` (Pull #159)
+
 ## 0.10.0 - 2021-01-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 - 2021-08-27
+## 0.11.0 - 2021-09-03
 
 ### Added
 

--- a/src/tartiflette_asgi/__init__.py
+++ b/src/tartiflette_asgi/__init__.py
@@ -1,5 +1,5 @@
 from ._app import TartifletteApp
 from ._datastructures import GraphiQL, Subscriptions
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 __all__ = ["GraphiQL", "Subscriptions", "TartifletteApp"]


### PR DESCRIPTION
## 0.11.0 - 2021-08-27

### Added

- Add official compatibility with Tartiflette 1.4.x. (Pull #153)

### Changed

- Update dependency on Starlette to `0.16.*`. (Pull #154)
- Refactor internal subscription streams (Pull #156)
- Update httpx requirement to `0.19.*` (Pull #159)