### PR TITLE
Turn on and address error-on-warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,7 @@ ignore_missing_imports = True
 profile = black
 known_first_party = tartiflette_asgi,tests
 known_third_party = asgi_lifespan,httpx,pyee,pytest,setuptools,starlette,tartiflette
+
+[tool:pytest]
+addopts =
+  -W error

--- a/tests/test_graphql_api.py
+++ b/tests/test_graphql_api.py
@@ -48,7 +48,7 @@ async def test_post_invalid_json(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
     async with get_client(app) as client:
         response = await client.post(
-            "/", data="{test", headers={"content-type": "application/json"}
+            "/", content="{test", headers={"content-type": "application/json"}
         )
     assert response.status_code == 400
     assert response.json() == {"error": "Invalid JSON."}
@@ -59,7 +59,7 @@ async def test_post_graphql(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
     async with get_client(app) as client:
         response = await client.post(
-            "/", data="{ hello }", headers={"content-type": "application/graphql"}
+            "/", content="{ hello }", headers={"content-type": "application/graphql"}
         )
     assert response.status_code == 200
     assert response.json() == {"data": {"hello": "Hello stranger"}}
@@ -70,7 +70,7 @@ async def test_post_invalid_media_type(engine: Engine) -> None:
     app = TartifletteApp(engine=engine)
     async with get_client(app) as client:
         response = await client.post(
-            "/", data="{ hello }", headers={"content-type": "dummy"}
+            "/", content="{ hello }", headers={"content-type": "dummy"}
         )
     assert response.status_code == 415
     assert response.text == "Unsupported Media Type"


### PR DESCRIPTION
HTTPX made `.request(..., data=...)` a deprecation warning. Let's address it, and turn on `-W error` in tests so that any future deprecation warning are dealt with (or explicitly ignored).