### PR TITLE
Switch to automatic PyPI uploads via CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: scripts/install
+      - name: Build package and docs
+        run: scripts/build
+      - name: Publish to PyPI & deploy docs
+        run: scripts/publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,9 @@ To make a new release:
 - Create a PR with the following:
   - Bump the package version by editing `__version__.py`.
   - Update the changelog with any relevant PRs merged since the last version: bug fixes, new features, changes, deprecations, removals.
-- Merge the PR.
-- Run `$ scripts/build` then `$ scripts/publish` on `master`.
-- Tag the commit and push the tag to the remote.
+- Get the PR reviewed and merged.
+- Once the release PR is reviewed and merged, create a new release on the GitHub UI, including:
+  - Tag version, like `0.11.0`.
+  - Release title, `Version 0.11.0`.
+  - Description copied from the changelog.
+- Once created, the release tag will trigger a 'publish' job on CI, automatically pushing the new version to PyPI.

--- a/scripts/publish
+++ b/scripts/publish
@@ -5,8 +5,19 @@ if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
 
-find src -type f -name "*.py[co]" -delete
-find src -type d -name __pycache__ -delete
+if [ ! -z "$GITHUB_ACTIONS" ]; then
+  git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git config --local user.name "GitHub Action"
+
+  VERSION=`grep __version__ ${VERSION_FILE} | grep -o '[0-9][^"]*'`
+
+  if [ "refs/tags/${VERSION}" != "${GITHUB_REF}" ] ; then
+    echo "GitHub Ref '${GITHUB_REF}' did not match package version '${VERSION}'"
+    exit 1
+  fi
+fi
+
+set -x
 
 ${PREFIX}twine upload dist/*
-${PREFIX}mkdocs gh-deploy
+${PREFIX}mkdocs gh-deploy --force


### PR DESCRIPTION
This PR switches the publish workflow so that:

- Releases happen on new tags
- When a tag is pushed (eg via a new release on GitHub), a `publish` job runs on GitHub Actions, that builds and pushes the package distribution to PyPI using an API token, configured in secrets as `PYPI_TOKEN`.

Follow-up to #160  - aims at streamlining the release process so that it's more easily doable by folks other than me.