### PR TITLE
Add support for variables in query parameters

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ wheel
 asgi-lifespan
 async-generator; python_version<'3.7'
 autoflake
-black==21.9b0
+black==22.3.0
 flake8
 flake8-bugbear
 flake8-comprehensions

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -49,12 +49,12 @@ def fixture_path(subscriptions: typing.Any) -> str:
 
 
 def _init(ws: WebSocket) -> None:
-    ws.send_json({"type": "connection_init"})
+    ws.send_json({"type": "connection_init"})  # type: ignore
     assert ws.receive_json() == {"type": "connection_ack"}
 
 
 def _terminate(ws: WebSocket) -> None:
-    ws.send_json({"type": "connection_terminate"})
+    ws.send_json({"type": "connection_terminate"})  # type: ignore
 
 
 def test_protocol_connect_disconnect(


### PR DESCRIPTION
### Context

Passing variables in the query string already seems to be accounted for in the codebase, but it's currently not working: Even though `_get_response` receives the variables, it's not decoding them as JSON.

This PR ensures that variables passed via query string are properly decoded and passed to the engine.

### Scope
- Decode query parameter `variables` as JSON for `GET` and `POST` requests
- Ensure that every supported querying method supports variables
- Add tests to cover variable handling
- Fix code checks that are currently failing [can be descoped and moved to a different PR if required]